### PR TITLE
7章 ユーザー登録

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -94,6 +94,83 @@ footer {
   }
 }
 
+@mixin box_sizing {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* miscellaneous */
+.debug_dump {
+  clear: both;
+  float: left;
+  width: 100%;
+  margin-top: 45px;
+  @include box_sizing;
+}
+
+/* sidebar */
+aside {
+  section.user_info {
+    margin-top: 20px;
+  }
+  section {
+    padding: 10px 0;
+    margin-top: 20px;
+    &:first-child {
+      border: 0;
+      padding-top: 0;
+    }
+    span {
+      display: block;
+      margin-bottom: 3px;
+      line-height: 1;
+    }
+    h1 {
+      font-size: 1.4em;
+      text-align: left;
+      letter-spacing: -1px;
+      margin-bottom: 3px;
+      margin-top: 0px;
+    }
+  }
+}
+
+.gravatar {
+  float: left;
+  margin-right: 10px;
+}
+
+.gravatar_edit {
+  margin-top: 15px;
+}
+
+/* forms */
+input, textarea, select, .uneditable-input {
+  border: 1px solid #bbb;
+  width: 100%;
+  margin-bottom: 15px;
+  @include box_sizing;
+}
+
+input {
+  height: auto !important;
+}
+
+#error_explanation {
+  color: red;
+  ul {
+    color: red;
+    margin: 0 0 30px 0;
+  }
+}
+
+.field_with_errors {
+  @extend .has-error;
+  .form-control {
+    color: $state-danger-text;
+  }
+}
 /* 画像が表示されなくなる
 img {
   display: none;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,25 @@
 class UsersController < ApplicationController
+
+  def show
+    @user = User.find(params[:id])
+  end
+
   def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      flash[:success] = "Welcome to the Sample App!"
+      redirect_to @user
+    else
+      render 'new'
+    end
+  end
+
+  private def user_params
+    params.require(:user).permit(:name, :email, :password,
+                                 :password_confirmation)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,8 @@
 module UsersHelper
+  # 引数で与えられたユーザーのGravatar画像を返す
+  def gravatar_for(user, size: 80)
+    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
+    image_tag(gravatar_url, alt: user.name, class: "gravatar")
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,8 +4,12 @@
   <body>
     <%= render 'layouts/header' %>
     <div class="container">
+      <% flash.each do |message_type, message| %>
+     　　<%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
+      <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>
+      <%= debug(params) if Rails.env.development? %>
     </div>
   </body>
 </html>

--- a/app/views/shared/_error_messages.erb
+++ b/app/views/shared/_error_messages.erb
@@ -1,0 +1,12 @@
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      The form contains <%= pluralize(@user.errors.count, "error") %>.
+    </div>
+    <ul>
+      <% @user.errors.full_messages.each do |error| %>
+        <li><%= error %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,23 @@
 <% provide(:title, 'Sign up') %>
 <h1>Sign up</h1>
-<p>This is be a signup page for users.</p>
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with model: @user, url: signup_path, local:true do |f| %>
+      <%= render 'shared/error_messages'%>
+
+      <%= f.label :name %>
+      <%= f.text_field :name, class: 'form-control '%>
+
+      <%= f.label :email %>
+      <%= f.text_field :email, class: 'form-control' %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Create My Account", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,11 @@
+<% provide(:title, @user.name) %>
+<div class="row" xmlns="http://www.w3.org/1999/html">
+  <aside class="col-md-4">
+    <section class="user_info">
+      <h1>
+        <%= gravatar_for @user, size:50 %>
+        <%= @user.name %>
+      </h1>
+    </section>
+  </aside>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
   get '/about', to: 'static_pages#about'
   get '/contact', to: 'static_pages#contact'
   get '/signup', to: 'users#new'
-
+  post '/signup', to: 'users#create'
+  resources :users
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class UsersSignupTest < ActionDispatch::IntegrationTest
+  test "invalid signup information" do
+    get signup_path
+    assert_no_difference 'User.count' do
+      post signup_path, params: {user: {
+          name: "", email: "user@invalid", password: "foo",
+          password_confirmation: "bar"}}
+    end
+    assert_template 'users/new'
+    assert_select 'form[action="/signup"]'
+    assert_select 'div#error_explanation'
+    assert_select 'div.field_with_errors'
+  end
+
+  test "valid signup information" do
+    get signup_path
+    assert_difference "User.count", 1 do
+      post signup_path, params: {user: {
+          name: "ExampleUser", email: "user@example.com",
+          password: "password", password_confirmation: "password"}}
+    end
+    follow_redirect!
+    assert_template 'users/show'
+    assert_not flash.empty?
+  end
+end


### PR DESCRIPTION
## 学んだこと
### 7.1 ユーザーを表示する
- RailsにはRailsというオブジェクトがあり、それには環境の論理値を取るenv属性がある。（development, test, productionのいずれか）
 - ミックスイン機能
CSSルールのグループをパッケージ化して複数の要素に適用できる
複数の要素に適用したいCSSに`@mixin`をつける
```
@mixin box_sizing {
  ...
}

.debug_dump {

@include box_sizing # 上で定義したbox_sizingの内容に変換される
}
```

### 7.2 ユーザー登録フォーム
- `form_for`はRails５.１から非推奨になったので`form_with`を使用

### 7.3 ユーザー登録失敗
- User.newの引数にparamsハッシュを丸ごと渡すのはセキュリティ上危険
- `Strong Parameters`を使うことで、必須のパラメータと許可されたパラメータを指定できる
以下のコードはuser属性を必須とし、name, email, password, password_confirmation属性はそれぞれ許可としている
```
params.require(:user).permit(:name, :email, :password, :password_confirmation)
```

- `pluralize`メソッドは最初の引数に整数が与えられると、２番目の引数の複数形に変更したものを返す
- Sassの`@extend`関数を使うことでCSSの継承ができる
- form_withだとエラーメッセージが表示されない
form_withはデフォルトでremote:trueとなってしまうためlocal:trueを指定する
remote:trueはAjax送信となるため、送信ボタンを押しても動作しない
- assert_no_differenceは引数の値が変わらないことをテストする

### 7.4 ユーザー登録成功
- `redirect_to @user`は、`redirect_to user_url(@user)`と同じ意味
- assert_differenceは第１引数にテスト対象、第２引数に変化する量を指定する
- `rails db:migrate:reset`でデータベースに登録されている内容をリセットできる

### 7.5 プロのデプロイ
