### PR TITLE
12章 パスワードの再設定

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="dataSourceStorageLocal">
+    <data-source name="development" uuid="008ab652-6951-46ca-896e-2cda97482c47">
+      <database-info product="" version="" jdbc-version="" driver-name="" driver-version="" dbms="SQLITE" exact-version="0" />
+      <auth-required>false</auth-required>
+      <schema-mapping />
+    </data-source>
+  </component>
+</project>

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="development" uuid="008ab652-6951-46ca-896e-2cda97482c47">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/db/development.sqlite3</jdbc-url>
+    </data-source>
+  </component>
+</project>

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,65 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update]
+
+  def new
+  end
+
+  def create
+    @user = User.find_by(email: params[:email])
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = 'Email sent with password reset instructions'
+      redirect_to root_url
+    else
+      flash.now[:danger] = 'Email address not found'
+      render 'new'
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if params[:user][:password].empty?
+      @user.errors.add(:password, :blank)
+      render 'edit'
+    elsif @user.update_attributes(user_params)
+      log_in @user
+      @user.update_attribute(:reset_digest, nil)
+      flash[:success] = 'Password has been reset.'
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  # beforeフィルタ
+
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  # 有効なユーザーか確認する
+  def valid_user
+    unless @user && @user.activated? && @user.authenticated?(:reset, params[:id])
+      redirect_to root_url
+    end
+  end
+
+  # トークンが期限切れか確認する
+  def check_expiration
+    if @user.password_reset_expired?
+      flash[:danger] = "Password reset has expired"
+      redirect_to new_password_reset_url
+    end
+  end
+end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,9 +15,8 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
-  def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: "Password reset"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest
   validates :name, presence: true, length: {maximum: 50}
@@ -47,8 +47,25 @@ class User < ApplicationRecord
     update_columns(activated: true, activated_at: Time.zone.now)
   end
 
+  # 有効化用のメールを送信する
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  # パスワード再設定の属性を設定する
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  # パスワード再設定のメールを送信する
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  # パスワード再設定の期限が切れている場合は場合はtrueを返す
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   private

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,19 @@
+<% provide(:title, 'Reset password') %>
+<h1>Reset password</h1>
+  <div class="row">
+    <div class="col-md-6 col-md-offset-3">
+      <%= form_with(model: @user, url: password_reset_path(params[:id]), local: true) do |f| %>
+        <%= render 'shared/error_messages' %>
+
+        <%= hidden_field_tag :email, @user.email %>
+
+        <%= f.label :password %>
+        <%= f.password_field :password, class: 'form-control' %>
+
+        <%= f.label :password_confirmation, "Confirmation" %>
+        <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+        <%= f.submit "Update password", class: "btn btn-primary" %>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, "Forgot password") %>
+<h1>Forgot password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: password_resets_path, local: true) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit "Submit", class: 'btn btn-primary' %>
+    <% end %>
+</div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,6 +8,7 @@
       <%= f.email_field :email, class: "form-control" %>
 
       <%= f.label :password %>
+      <%= link_to "(forgot password)", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,13 @@
-<h1>User#password_reset</h1>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
+                                                      email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+  If you did not request your password to be reset, please ignore this email and
+  your password will stay as it is.
 </p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,8 @@
-User#password_reset
+To reset your password click the link below:
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20200222143058_add_reset_to_users.rb
+++ b/db/migrate/20200222143058_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_20_042951) do
+ActiveRecord::Schema.define(version: 2020_02_22_143058) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2020_02_20_042951) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class PasswordResetsTest < ActionDispatch::IntegrationTest
+
+  def setup
+    ActionMailer::Base.deliveries.clear
+    @user = users(:michael)
+  end
+
+  test "password resets" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    # メールアドレスが無効
+    post password_resets_path, params: { password_reset: { email: "" } }
+    assert_not flash.empty?
+    assert_template 'password_resets/new'
+    # メールアドレスが有効
+    post password_resets_path,
+         params: { password_reset: { email: @user.email } }
+    assert_not_equal @user.reset_digest, @user.reload.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_not flash.empty?
+    assert_redirected_to root_url
+    # パスワード再設定フォームのテスト
+    user = assigns(:user)
+    # メールアドレスが無効
+    get edit_password_reset_path(user.reset_token, email: "")
+    assert_redirected_to root_url
+    # 無効なユーザー
+    user.toggle!(:activated)
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_redirected_to root_url
+    user.toggle!(:activated)
+    # メールアドレスが有効で、トークンが無効
+    get edit_password_reset_path('wrong token', email: user.email)
+    assert_redirected_to root_url
+    # メールアドレスもトークンも有効
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_template 'password_resets/edit'
+    assert_select "input[name=email][type=hidden][value=?]", user.email
+    # 無効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "foobaz",
+                            password_confirmation: "barquux" } }
+    assert_select 'div#error_explanation'
+    # パスワードが空
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "",
+                            password_confirmation: "" } }
+    assert_select 'div#error_explanation'
+    # 有効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "foobaz",
+                            password_confirmation: "foobaz" } }
+    assert is_logged_in?
+    assert_not flash.empty?
+    assert_redirected_to user
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -10,7 +10,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -15,12 +15,14 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match CGI.escape(user.email), mail.body.encoded
   end
 
-  # test "password_reset" do
-  #   mail = UserMailer.password_reset
-  #   assert_equal "Password reset", mail.subject
-  #   assert_equal ["to@example.org"], mail.to
-  #   assert_equal ["from@example.com"], mail.from
-  #   assert_match "Hi", mail.body.encoded
-  # end
-
+  test "password_reset" do
+    user = users(:michael)
+    user.reset_token = User.new_token
+    mail = UserMailer.password_reset(user)
+    assert_equal "Password reset", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.reset_token,        mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
+  end
 end


### PR DESCRIPTION
## 学んだこと
### 12.1 Passwords Resetsリソース
コントローラ作成時、テストを作成しないオプション
```
rails generate controller PasswordResets new edit --no-test-framework
```
パスワード再設定用のリンクは期限を設けるため、送信時刻保存用のカラム作成する

### 12.2 パスワード再設定のメール送信
マイグレーションの履歴を確認するコマンド
```
rails db:migrate:status
```

### 12.3 パスワードを再設定する
f.hidden_fieldだとparams[:user][email]に保存されるが、`hidden_field_tag`を使うと、`params[:email]`に保存される
```
hidden_field_tag :email, @user.email
```

inputタグのhidden属性があるかテストする
```
assert_select "input[name=email][type=hidden][value=?]", user.email
```